### PR TITLE
ユーザー認証の導入

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,14 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :basic_auth
 
   private
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
+    end
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up,


### PR DESCRIPTION
# What
Basic認証の作成

# Why
ユーザー認証を導入するため

本番環境でフリマアプリの挙動を確認いただいたところ、Basic認証が実装されていないことがわかりました。コードを修正したため、確認していただけますと幸いです。何卒よろしくお願い申し上げます。